### PR TITLE
Add base SDK types

### DIFF
--- a/src/types/encoders.ts
+++ b/src/types/encoders.ts
@@ -1,0 +1,30 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
+
+export interface InitDataFairSaleOptions {
+  saleLauncher: string
+  saleTemplateId: BigNumberish
+  tokenOut: string
+  tokenIn: string
+  duration: BigNumberish
+  tokenOutSupply: BigNumberish
+  minPrice: BigNumber
+  minBuyAmount: BigNumber
+  minRaise: BigNumber
+  tokenSupplier: string
+}
+
+export interface InitDataFixedPriceSaleOptions {
+  saleLauncher: string
+  saleTemplateId: BigNumberish
+  tokenSupplier: string
+  tokenOut: string
+  tokenIn: string
+  tokenPrice: BigNumberish
+  tokensForSale: BigNumberish
+  startDate: BigNumberish
+  endDate: BigNumberish
+  allocationMin: BigNumberish
+  allocationMax: BigNumberish
+  minimumRaise: BigNumberish
+  owner: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,36 @@
+// Externals
+import { BigNumber, providers } from 'ethers'
+// Contracts
+import { MesaFactory, SaleLauncher, TemplateLauncher } from 'src/contracts'
+// Subgraph
+import { Subgraph } from 'src/Subgraph'
+
+export interface CreateInstanceOptions {
+  factory: string
+  saleLauncher: string
+  templateLauncher: string
+  provider: providers.Provider
+  subgraphEndpoint: string
+}
+
+export interface Contracts {
+  factory: MesaFactory
+  saleLauncher: SaleLauncher
+  templateLauncher: TemplateLauncher
+}
+
+export interface MesaInstance {
+  contracts: Contracts
+  subgraph: Subgraph
+  provider: providers.Provider
+}
+
+export interface AddSaleOptions {
+  mesa: MesaInstance
+  sale: string
+}
+
+export interface AddTemplateOptions {
+  mesa: MesaInstance
+  template: string
+}

--- a/src/types/sales.ts
+++ b/src/types/sales.ts
@@ -1,0 +1,9 @@
+import { InitDataFixedPriceSaleOptions } from './encoders'
+
+/**
+ * Builds FixedPriceSaleOptions from the encoder data by excluding saleLauncher and saleTemplateId fields
+ */
+export type FixedPriceSaleOptions = Pick<
+  InitDataFixedPriceSaleOptions,
+  Exclude<keyof InitDataFixedPriceSaleOptions, 'saleLauncher' | 'saleTemplateId'>
+>

--- a/src/types/subgraph.ts
+++ b/src/types/subgraph.ts
@@ -1,0 +1,87 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
+export type BooleanMap<T = any> = {
+  [key in keyof T]: boolean
+}
+
+/**
+ * Schema timestamp fields
+ */
+export interface DocumentTimestampFields {
+  createdAt: number
+  updatedAt: number
+  deletedAt: number | null // null indicates if documnet has been deletec
+}
+
+interface SubgraphSchema {
+  [key: string]: any
+}
+
+/**
+ * MesaFactory
+ */
+export interface MesaFactory extends SubgraphSchema {
+  id: string
+  saleCount: number
+  address: string
+  feeManager: string
+  feeTo: string
+  templateManager: string
+  templateLauncher: string
+  saleFee: BigNumber
+  feeNumerator: BigNumber
+  templateFee: BigNumber
+}
+
+/**
+ * SaleTemplate
+ */
+export interface SaleTemplate extends SubgraphSchema, DocumentTimestampFields {
+  id: number
+  address: string
+  factory: string
+  name: string
+  verified: boolean
+}
+
+/**
+ * Generic Token
+ */
+export interface Token extends SubgraphSchema, DocumentTimestampFields {
+  id: string
+  name: String
+  symbol: String
+  decimals: number
+}
+
+/**
+ *
+ */
+export interface FixedPriceSaleBase<TokenType = string> extends SubgraphSchema, DocumentTimestampFields {
+  id: string
+  name: string
+  status: string
+  startDate: number
+  endDate: number
+  sellAmount: BigNumber
+  minimumRaise: BigNumber
+  allocationMin: BigNumber
+  allocationMax: BigNumber
+  tokenIn: TokenType
+  tokenOut: TokenType
+  purchases: FixedPriceSalePurchase[]
+}
+
+/**
+ *
+ */
+export interface FixedPriceSalePopulated extends FixedPriceSaleBase<Token> {}
+
+/**
+ * FixedPriceSalePurchase
+ */
+export interface FixedPriceSalePurchase extends SubgraphSchema, DocumentTimestampFields {
+  sale: string
+  buyer: string
+  amount: BigNumber
+}


### PR DESCRIPTION
A preliminary version of the types used by the SDK

- Encoders
- Subgraph
- Sales
- Generic