### PR TITLE
Update publication requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,18 @@
     "type": "git",
     "url": "git+https://github.com/cryptonative-ch/mesa-js.git"
   },
-  "keywords": [],
+  "files": [
+    "LICENSE.md",
+    "README.md",
+    "dist/"
+  ],
+  "keywords": [
+    "dxdao",
+    "mesa",
+    "ethereum",
+    "web3",
+    "DeFi"
+  ],
   "author": "Adam Azad <adam@adamazad.com> (https://adamazad.com/)",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,18 @@
   "main": "dist/index.js",
   "dependencies": {
     "@ethersproject/providers": "^5.1.2",
-    "@typechain/ethers-v5": "^6.0.5",
     "axios": "^0.21.1",
-    "ethers": "^5.1.0",
+    "ethers": "^5.1.0"
+  },
+  "devDependencies": {
+    "@typechain/ethers-v5": "^6.0.5",
+    "@types/graphql": "^14.5.0",
+    "apollo": "^2.32.8",
+    "dayjs": "^1.10.4",
     "nodemon": "^2.0.7",
     "typechain": "^4.0.3",
     "typescript": "^4.2.4"
   },
-  "devDependencies": {},
   "scripts": {
     "typechain": "typechain --target ethers-v5 --outDir src/contracts abis/*.json",
     "build-abis": "build-abis.sh",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@dxdao/mesa",
-  "version": "1.0.0",
-  "description": "MesaJS gives developer access to the entire Mesa ecosystem a single package",
+  "version": "0.1.0",
+  "private": false,
+  "description": "MesaJS gives developers access to the entire Mesa ecosystem a single package",
   "main": "dist/index.js",
   "dependencies": {
     "@ethersproject/providers": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "keywords": [],
   "author": "Adam Azad <adam@adamazad.com> (https://adamazad.com/)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/cryptonative-ch/mesa-js/issues"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "devDependencies": {},
   "scripts": {
     "typechain": "typechain --target ethers-v5 --outDir src/contracts abis/*.json",
-    "build-abis": "build-abis.sh"
+    "build-abis": "build-abis.sh",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Clean up extra dependencies
- Add build scripts
- Use `0.1.0` first version 
- Update license