### PR TITLE
Updated to aqua-xdai-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxdao/mesa",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "private": false,
   "description": "MesaJS gives developers access to the entire Mesa ecosystem a single package",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export const XDAI_CONFIG: MesaConfigMap = {
   factory: '0x6897427e8d129d040F066a3Dcb106da91e84ab47',
   saleLauncher: '0xfa4Fbd5DC4a0C3aE54aA3a1fE52099d7d6F94227',
   templateLauncher: '0x1c1006D122A7f09A047f42D16464A3e7fBdB24C2',
-  subgraph: 'https://api.thegraph.com/subgraphs/name/adamazad/aqua-xdai-dev',
+  subgraph: 'https://api.thegraph.com/subgraphs/name/adamazad/aqua-xdai-next',
 }
 
 export const RINKEBY_CONFIG: MesaConfigMap = {


### PR DESCRIPTION
For the new SC to work in the UI this new release is needed and it is set in here.
In future I think this should be an environment variable on the UI side since I think this is also causing the netlify subgraph error.
This also needs to be published to npm for the UI to use